### PR TITLE
Update interop to use BigInt when converting Number to long

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,5 +7,5 @@ plugins {
 
 allprojects {
     group = "io.ygdrasil"
-    version = System.getenv("VERSION")?.takeIf { it.isNotBlank() } ?: "0.0.2-SNAPSHOT"
+    version = System.getenv("VERSION")?.takeIf { it.isNotBlank() } ?: "0.0.3-SNAPSHOT"
 }

--- a/webgpu-ktypes-web/src/wasmJsMain/kotlin/interop.wasmJs.kt
+++ b/webgpu-ktypes-web/src/wasmJsMain/kotlin/interop.wasmJs.kt
@@ -66,7 +66,7 @@ internal fun externRefToKotlinLongAdapter(x: JsAny): Long =
     externrefToLong(x)
 
 private fun externrefToLong(ref: JsAny): Long =
-    js("Number(ref)")
+    js("BigInt(ref)")
 
 public fun kotlin.js.JsNumber.toShort(): Short =
     externRefToKotlinShortAdapter(this)


### PR DESCRIPTION
Replaced `Number` with `BigInt` for externref conversion to ensure support for larger values. Incremented the project version from 0.0.2-SNAPSHOT to 0.0.3-SNAPSHOT.