### PR TITLE
Add `size` property to `ArrayBuffer` native

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,5 +7,5 @@ plugins {
 
 allprojects {
     group = "io.ygdrasil"
-    version = System.getenv("VERSION")?.takeIf { it.isNotBlank() } ?: "0.0.3-SNAPSHOT"
+    version = System.getenv("VERSION")?.takeIf { it.isNotBlank() } ?: "0.0.5-SNAPSHOT"
 }

--- a/webgpu-ktypes/src/commonNativeMain/kotlin/ArrayBuffer.kt
+++ b/webgpu-ktypes/src/commonNativeMain/kotlin/ArrayBuffer.kt
@@ -9,7 +9,16 @@ package io.ygdrasil.webgpu
  * It acts as a generic container for binary data, allowing a variety
  * of typed views to be created over the data it encapsulates.
  *
- * @constructor Creates an ArrayBuffer with a given raw pointer to memory.
+ * @constructor Creates an ArrayBuffer with a given raw pointer to memory and size.
  * @property rawPointer A ULong representing the raw memory pointer this buffer wraps.
+ * It is typically used to point to memory allocated for binary data.
+ * @property size A ULong representing the total length of the memory block
+ * in bytes that this buffer encapsulates. This helps define the usable range in memory.
+ *
+ * Example usage:
+ * ```Kotlin
+ * val buffer = ArrayBuffer(rawPointer = 12345678uL, size = 1024uL)
+ * println("Raw Pointer: ${buffer.rawPointer}, Size: ${buffer.size} bytes")
+ * ```
  */
-actual class ArrayBuffer(val rawPointer: ULong)
+actual class ArrayBuffer(val rawPointer: ULong, val size: ULong)


### PR DESCRIPTION
The `size` property defines the total length of the memory block in bytes, making the buffer's range and usage clearer. Documentation and an example usage snippet were updated accordingly to reflect this change.